### PR TITLE
skip the blanks in define parameters

### DIFF
--- a/ApiExtractor/parser/rpp/pp-engine-bits.h
+++ b/ApiExtractor/parser/rpp/pp-engine-bits.h
@@ -588,6 +588,8 @@ _InputIterator pp::handle_define(_InputIterator __first, _InputIterator __last)
             }
         }
 
+        __first = skip_blanks(__first, __last);
+
         assert(*__first == ')');
         ++__first;
     }


### PR DESCRIPTION
This patch is fixing debug assertion parsing defines
with spaces before the close bracket.

#define FOO( arg )

Signed-off-by: Anton Sergunov <anton@ahead.io>